### PR TITLE
Don't add the login form to Ajax content

### DIFF
--- a/wds-custom-login-page.php
+++ b/wds-custom-login-page.php
@@ -197,6 +197,10 @@ if ( ! class_exists( 'WDS_Custom_Login_Page' ) ) {
 		 * Default login form if there's no login template found
 		 */
 		public function insert_login_form( $content ) {
+			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+				return $content; // Don't do it over Ajax.
+			}
+
 			// Bail if we aren't on the login page.
 			if ( ! is_admin() && ! is_page( 'login' ) && ! is_page( wds_login_slug() ) ) {
 				return $content;


### PR DESCRIPTION
On a specific project I was experiencing content that was processed via
the_content filter was returning the login form.
