### PR TITLE
Check for this function because in some situations CMB2 may not be loaded

### DIFF
--- a/inc/options.php
+++ b/inc/options.php
@@ -166,7 +166,9 @@ function wds_login_options() {
  * @return mixed       Option value
  */
 function wds_login_get_option( $key = '' ) {
-	return cmb2_get_option( wds_login_options()->key, $key );
+	if ( function_exists( 'cmb2_get_option' ) ) {
+		return cmb2_get_option( wds_login_options()->key, $key );
+	}
 }
 
 function wds_login_page() {


### PR DESCRIPTION
Was seeing a notice being thrown for this on a project, I assume CMB2 is not
loaded when this is called.
